### PR TITLE
chore: remove unused rlib directory from node_modules

### DIFF
--- a/rlib
+++ b/rlib
@@ -1,1 +1,0 @@
-/Users/riz/Developer/sim-klinik/node_modules/rlib


### PR DESCRIPTION
Delete the rlib folder from node_modules to clean up unused dependencies and reduce project clutter. This helps maintain a leaner project structure and avoids potential confusion.