### PR TITLE
refactor(init): rename initBaseUrlFile to initBaseFile and update .gi…

### DIFF
--- a/server/init/base-file.ts
+++ b/server/init/base-file.ts
@@ -1,6 +1,6 @@
 import { dir } from "../util/dir";
 
-export const initBaseUrlFile = async () => {
+export const initBaseFile = async () => {
   dir.ensure("frontend:src/lib/gen");
 
   await Bun.file(dir.path("frontend:src/lib/gen/base-url.ts")).write(`\
@@ -10,4 +10,36 @@ import raw_config from "../../../../config.json";
 const config = raw_config satisfies SiteConfig;
 export const baseUrl = defineBaseUrl(config);
 `);
+
+  await ensureGitIgnore([
+    "frontend/src/lib/gen",
+    "frontend/src/lib/gen/*",
+    "backend/src/gen",
+    "backend/src/gen/*",
+  ]);
 };
+
+export async function ensureGitIgnore(patterns: string[]): Promise<void> {
+  const gitignorePath = dir.path("root:.gitignore");
+  let content = "";
+
+  try {
+    content = await Bun.file(gitignorePath).text();
+  } catch (error) {
+    // File may not exist yet, continue with empty content
+  }
+
+  const lines = content.split("\n");
+  const newPatterns = patterns.filter((pattern) => !lines.includes(pattern));
+
+  if (newPatterns.length > 0) {
+    // Add a blank line if the file doesn't end with one and has content
+    const appendContent =
+      content.length > 0 && !content.endsWith("\n\n")
+        ? "\n\n" + newPatterns.join("\n") + "\n"
+        : newPatterns.join("\n") + "\n";
+
+    await Bun.file(gitignorePath).write(content + appendContent);
+    console.log(`Added patterns to .gitignore: ${newPatterns.join(", ")}`);
+  }
+}

--- a/server/init/dev.ts
+++ b/server/init/dev.ts
@@ -7,7 +7,7 @@ import { spaHandler } from "../util/spa-handler";
 import { staticFileHandler } from "../util/static-handler";
 import { initEnv } from "./env";
 import { initHandler, type onFetch } from "./handler";
-import { initBaseUrlFile } from "./base-file";
+import { initBaseFile } from "./base-file";
 
 export const initDev = async ({
   index,
@@ -27,7 +27,7 @@ export const initDev = async ({
 
   if (isDev) {
     if (!isLiveReload) {
-      await initBaseUrlFile();
+      await initBaseFile();
       await buildAPI(apiConfig);
       await buildPages(pageConfig);
     }

--- a/server/init/prod.ts
+++ b/server/init/prod.ts
@@ -11,7 +11,7 @@ import {
   type onFetch,
 } from "../../server";
 import { initEnv } from "./env";
-import { initBaseUrlFile } from "./base-file";
+import { initBaseFile } from "./base-file";
 
 export const initProd = async ({
   loadApi,
@@ -25,7 +25,7 @@ export const initProd = async ({
   const { apiConfig, isDev, isLiveReload, pageConfig } = initEnv();
   if (isDev) return null;
 
-  await initBaseUrlFile();
+  await initBaseFile();
   await buildAPI(apiConfig);
   await buildPages(pageConfig);
 


### PR DESCRIPTION
…tignore

Rename the function initBaseUrlFile to initBaseFile for clarity and consistency across dev and prod initialization modules. Add ensureGitIgnore utility to append necessary generated directories to .gitignore automatically, preventing unintended commits of generated files. This improves project hygiene and reduces manual .gitignore maintenance.